### PR TITLE
feat: sitemap MongoDB storage + auto health check after startup and cron

### DIFF
--- a/app.js
+++ b/app.js
@@ -206,41 +206,40 @@ app.use((err, req, res, next) => {
 app.listen(PORT, "0.0.0.0", () => {
   console.log("Backend Server Started on PORT : ", PORT);
 
-  // ── Sitemap: generate on startup + schedule every 2 hours ────
-  generateSitemap()
-    .then((result) => {
-      if (result.success) {
-        console.log(`[Sitemap] Startup generation complete — ${result.urlCount} URLs`);
-      } else {
-        console.warn("[Sitemap] Startup generation failed:", result.error);
-      }
-    })
-    .catch((err) => console.error("[Sitemap] Startup generation error:", err));
+  // ── Helper: generate sitemap + run health check ───────────────
+  async function generateAndClean(reason) {
+    const result = await generateSitemap();
+    if (!result.success) {
+      console.warn(`[Sitemap] Generation failed (${reason}):`, result.error);
+      return;
+    }
+    console.log(`[Sitemap] ${reason} generation complete — ${result.urlCount} URLs`);
 
-  // Cron: every 2 hours at minute 0 (00:00, 02:00, 04:00, ...)
-  const sitemapCron = new CronJob("0 */2 * * *", async () => {
-    console.log("[Sitemap] Cron triggered — regenerating...");
-    await generateSitemap();
-  });
-  sitemapCron.start();
-  console.log("[Sitemap] Cron scheduled — every 2 hours");
-
-  // Cron: daily health check at 03:30 AM (after the 02:00 sitemap regen)
-  const healthCheckCron = new CronJob("30 3 * * *", async () => {
-    console.log("[SitemapAudit] Daily health check triggered...");
+    // Auto health check after startup and cron (not CRUD-triggered)
     try {
-      const result = await runHealthCheck();
-      if (result.badUrls > 0) {
+      console.log(`[SitemapAudit] Auto health check starting (${reason})...`);
+      const audit = await runHealthCheck();
+      if (audit.badUrls > 0) {
         console.log(
-          `[SitemapAudit] Removed ${result.removed} bad URLs (run: ${result.auditRunId})`
+          `[SitemapAudit] Removed ${audit.removed} bad URLs (run: ${audit.auditRunId})`
         );
       } else {
         console.log("[SitemapAudit] All URLs healthy — nothing to remove");
       }
     } catch (err) {
-      console.error("[SitemapAudit] Daily health check failed:", err);
+      console.error(`[SitemapAudit] Auto health check failed (${reason}):`, err);
     }
+  }
+
+  // ── Sitemap: generate + clean on startup ─────────────────────
+  generateAndClean("Startup")
+    .catch((err) => console.error("[Sitemap] Startup error:", err));
+
+  // Cron: every 2 hours — regenerate + auto health check
+  const sitemapCron = new CronJob("0 */2 * * *", async () => {
+    console.log("[Sitemap] Cron triggered — regenerating...");
+    await generateAndClean("Cron");
   });
-  healthCheckCron.start();
-  console.log("[SitemapAudit] Daily health check scheduled — 03:30 AM");
+  sitemapCron.start();
+  console.log("[Sitemap] Cron scheduled — every 2 hours (with auto health check)");
 });

--- a/utils/generateSitemap/sitemapHealthCheck.js
+++ b/utils/generateSitemap/sitemapHealthCheck.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 const SitemapAuditLog = require("../../models/sitemapAuditLog");
+const Sitemap = require("../../models/sitemap");
 
 const SITEMAP_PATH = path.join(__dirname, "../../public/sitemap.xml");
 
@@ -92,7 +93,7 @@ function extractUrlsFromSitemap() {
  * Remove specific URLs from the sitemap XML file.
  * Removes the entire <url>...</url> block for each bad URL.
  */
-function removeUrlsFromSitemap(urlsToRemove) {
+async function removeUrlsFromSitemap(urlsToRemove) {
   if (urlsToRemove.length === 0) return 0;
 
   let xml = fs.readFileSync(SITEMAP_PATH, "utf8");
@@ -119,7 +120,21 @@ function removeUrlsFromSitemap(urlsToRemove) {
   }
 
   if (removedCount > 0) {
+    // Save cleaned sitemap to local disk
     fs.writeFileSync(SITEMAP_PATH, xml, { encoding: "utf8" });
+
+    // Also update MongoDB so all instances serve the cleaned version
+    try {
+      const urlCount = (xml.match(/<loc>/g) || []).length;
+      await Sitemap.findOneAndUpdate(
+        {},
+        { content: xml, urlCount, generatedAt: new Date() },
+        { upsert: true }
+      );
+      console.log(`[SitemapAudit] Updated MongoDB with cleaned sitemap (${urlCount} URLs)`);
+    } catch (mongoErr) {
+      console.warn(`[SitemapAudit] MongoDB update failed (non-fatal): ${mongoErr.message}`);
+    }
   }
 
   return removedCount;
@@ -184,7 +199,7 @@ async function runHealthCheck(onProgress) {
   if (badResults.length > 0) {
     // 4. Remove bad URLs from sitemap
     const urlsToRemove = badResults.map((r) => r.url);
-    const removedCount = removeUrlsFromSitemap(urlsToRemove);
+    const removedCount = await removeUrlsFromSitemap(urlsToRemove);
     console.log(`[SitemapAudit] Removed ${removedCount} URLs from sitemap`);
 
     // 5. Log to MongoDB


### PR DESCRIPTION
- Add Sitemap model — single-document MongoDB storage for multi-instance consistency
- generateSitemap saves XML to MongoDB after disk write
- Health check saves cleaned sitemap to MongoDB after removing bad URLs
- Serve sitemap from MongoDB first, local file as fallback
- Auto health check runs after startup and 2h cron (not CRUD-triggered)
- Remove separate daily 3:30 AM cron (now covered by 2h cycle)