### PR TITLE
Sitemap: nested /[hub]/[sub-category]/[slug] URLs for articles with a sub_category

### DIFF
--- a/utils/generateSitemap/generateSitemap.js
+++ b/utils/generateSitemap/generateSitemap.js
@@ -402,32 +402,44 @@ const generateSitemap = async (onProgress) => {
     // aren't in MongoDB will get added; duplicates are caught by the Map.
     const strapiArticles = await fetchStrapiAll(
       "/api/articles",
-      "fields[0]=slug&fields[1]=updatedAt&populate[category][fields][0]=slug"
+      "fields[0]=slug&fields[1]=updatedAt&populate[category][fields][0]=slug&populate[sub_category][fields][0]=slug"
     );
+
+    // Map category slug → hub base path.
+    const HUB_BASE = {
+      news: "/real-estate-news/",
+      blog: "/blogs/",
+      publications: "/our-publications/",
+    };
+
+    let nestedArticleCount = 0;
     for (const article of strapiArticles) {
       const slug = article.slug;
       const categorySlug = article.category?.slug;
-      if (!slug || !categorySlug) continue;
+      const hubBase = HUB_BASE[categorySlug];
+      if (!slug || !hubBase) continue;
 
-      let articlePath = "";
-      if (categorySlug === "news") {
-        articlePath = `/real-estate-news/${encodeURIComponent(slug)}/`;
-      } else if (categorySlug === "blog") {
-        articlePath = `/blogs/${encodeURIComponent(slug)}/`;
-      } else if (categorySlug === "publications") {
-        articlePath = `/our-publications/${encodeURIComponent(slug)}/`;
+      const subSlug = article.sub_category?.slug;
+      const lastmod = new Date(article.updatedAt).toISOString();
+
+      if (subSlug) {
+        // Canonical URL is nested: /{hub}/{sub-category}/{slug}/
+        // Only the Strapi article entry is affected here — MongoDB-sourced
+        // URLs (properties, legacy blogs/news) are left untouched.
+        addUrl(
+          `${hubBase}${encodeURIComponent(subSlug)}/${encodeURIComponent(slug)}/`,
+          lastmod,
+          "daily",
+          "0.9"
+        );
+        nestedArticleCount++;
       } else {
-        continue;
+        addUrl(`${hubBase}${encodeURIComponent(slug)}/`, lastmod, "daily", "0.9");
       }
-
-      addUrl(
-        articlePath,
-        new Date(article.updatedAt).toISOString(),
-        "daily",
-        "0.9"
-      );
     }
-    console.log(`[Sitemap] Articles (Strapi): ${strapiArticles.length}`);
+    console.log(
+      `[Sitemap] Articles (Strapi): ${strapiArticles.length} (${nestedArticleCount} nested under a sub-category)`
+    );
 
     // ── 10. Remove redirect source paths ───────────────────────
     reportProgress("dedup", { message: "Removing redirect sources & deduplicating…", urlCount: urlMap.size });


### PR DESCRIPTION
## What

Updates the sitemap generator so **Strapi articles** that have a **`sub_category`** are listed at their canonical **nested** URL — matching the new frontend routing in `xr_client`: `/blogs/[sub-category]/[slug]`, and likewise for `/real-estate-news/` and `/our-publications/`.

## Why

The frontend now serves article detail pages at `/{hub}/{sub-category}/{slug}/` and **308-redirects** the old flat `/{hub}/{slug}/` URLs to them. For SEO, the sitemap should advertise the **final canonical URL** rather than one that redirects.

## Change

Scoped entirely to the **Strapi articles** step (step 9) of `utils/generateSitemap/generateSitemap.js`:

- Populates `sub_category.slug` in addition to `category.slug`.
- When an article **has** a sub-category → emits `/{hub}/{sub-category}/{slug}/`.
- When an article has **no** sub-category → emits the flat `/{hub}/{slug}/` (unchanged).

**Only the Strapi article entries are affected.** MongoDB-sourced URLs — properties and the legacy `Content` blogs/news — are left completely untouched. The MongoDB `Content` collection and the Strapi `articles` collection hold **entirely separate content** (no shared slugs), so there is no risk of a flat+nested duplicate for the same article.

## Safety / rollout

- **Inert until data exists.** Today every article has `sub_category: null`, so output matches the current flat sitemap (`nestedArticleCount = 0`). Nested URLs appear only as editors assign sub-categories — in lockstep with the frontend redirects.
- `node --check` passes.