### PR TITLE
Revalidate frontend cache on redirect create/update/delete

### DIFF
--- a/routes/redirect.js
+++ b/routes/redirect.js
@@ -4,6 +4,51 @@ const router = express.Router();
 const Redirect = require("../models/redirect");
 const { isLoggedIn, isAdmin } = require("../middleware/middleware");
 
+// ── Frontend cache revalidation ─────────────────────────────────────────────
+// The Next.js frontend serves these MongoDB redirects through a runtime proxy
+// that caches the rule map (CMS data-cache ~5 min + per-instance proxy cache
+// ~2 min). Without a nudge, a new/edited redirect takes minutes to go live.
+//
+// Worse, when a redirect accompanies an article MOVE (e.g. our-publications →
+// blog), the frontend's per-article data cache still holds the OLD category for
+// ~5 min, so the article page keeps canonical-redirecting the new URL back to
+// the old one while this rule redirects old → new — a redirect LOOP until the
+// caches expire.
+//
+// Firing the frontend's /api/revalidate on every redirect mutation busts both:
+//   - tag "redirects"      → the redirect map updates immediately
+//   - tag "article:<slug>" → the moved article's canonical updates immediately,
+//                            so it can't redirect back (kills the loop)
+//
+// Fire-and-forget: a revalidation failure must NEVER break the redirect CRUD
+// (the frontend still falls back to its cache TTLs). Requires REVALIDATE_SECRET
+// (same value the frontend checks) — when unset, this safely no-ops.
+const MAIN_FRONTEND_URL =
+  process.env.MAIN_FRONTEND_URL || "https://www.xrealty.ae";
+const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET || "";
+
+// Best-effort article slug = last non-empty path segment of a site-relative URL.
+function slugFromPath(path) {
+  if (typeof path !== "string") return "";
+  const clean = path.split("?")[0].split("#")[0].replace(/\/+$/, "");
+  return clean.split("/").filter(Boolean).pop() || "";
+}
+
+function revalidateFrontend(affectedTo) {
+  if (!REVALIDATE_SECRET) return; // not configured → rely on frontend cache TTLs
+  const tags = ["redirects"];
+  const slug = slugFromPath(affectedTo);
+  if (slug) tags.push(`article:${slug}`);
+  fetch(`${MAIN_FRONTEND_URL}/api/revalidate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ secret: REVALIDATE_SECRET, tags }),
+    signal: AbortSignal.timeout(5000),
+  }).catch((err) => {
+    console.error("[redirect] frontend revalidate failed:", err.message);
+  });
+}
+
 // Get redirect rules with optional pagination and search
 router.get("/", async (req, res) => {
   try {
@@ -67,6 +112,7 @@ router.post("/", isLoggedIn, isAdmin, async (req, res) => {
 
     const newRedirect = new Redirect({ from, to, type });
     await newRedirect.save();
+    revalidateFrontend(to);
     res.status(201).json(newRedirect);
   } catch (error) {
     console.error("Error creating redirect:", error);
@@ -97,6 +143,7 @@ router.put("/:id", isLoggedIn, isAdmin, async (req, res) => {
       return res.status(404).json({ message: "Redirect not found." });
     }
 
+    revalidateFrontend(to);
     res.status(200).json(updatedRedirect);
   } catch (error) {
     console.error("Error updating redirect:", error);
@@ -115,6 +162,7 @@ router.delete("/:id", isLoggedIn, isAdmin, async (req, res) => {
       return res.status(404).json({ message: "Redirect not found." });
     }
 
+    revalidateFrontend(deletedRedirect.to);
     res.status(200).json({ message: "Redirect deleted successfully." });
   } catch (error) {
     console.error("Error deleting redirect:", error);


### PR DESCRIPTION
## Why

The Next.js frontend (`www.xrealty.ae`) serves these MongoDB redirect rules through a runtime proxy that caches the rule map, and it caches each **article's data (including its `category` → canonical URL) for ~5 minutes**. Two problems followed every redirect save:

1. **Slow propagation** — a new/edited redirect took minutes (CMS data-cache ~5 min + per-instance proxy cache ~2 min) to go live.
2. **Redirect loop on article moves** — when a redirect accompanied a hub move (e.g. `our-publications → blog`), the article page kept canonical-redirecting the **new** URL back to the **old** one (its cached data still showed the old category) while this rule redirected **old → new**. Result: `/blogs/... ↔ /our-publications/...` ping-pong until the caches expired. (Reported on `/our-publications/market-pulse/etihad-rail-uae-gcc-railway-project-2025/`.)

## What

Fire the frontend's `POST /api/revalidate` (fire-and-forget) after every redirect **create / update / delete**, busting:

- **`redirects`** → the proxy's rule map refreshes immediately.
- **`article:<slug>`** → the moved article's cached data refreshes immediately, so its canonical flips to the new hub and it stops redirecting back. **This is what kills the loop.** `<slug>` is derived from the redirect target's last path segment.

```js
POST {MAIN_FRONTEND_URL}/api/revalidate
{ "secret": "<REVALIDATE_SECRET>", "tags": ["redirects", "article:<slug>"] }
```

## Safety

- **Fire-and-forget**: a revalidation failure is logged and **never blocks the redirect CRUD** (the frontend still falls back to its cache TTLs).
- **No-ops when unconfigured**: if `REVALIDATE_SECRET` is unset, the call is skipped entirely.
- 5s timeout on the request.

## Required config

- `REVALIDATE_SECRET` — **must match** the value the frontend verifies on `/api/revalidate` (already added on the frontend). Set it in this service's env.
- `MAIN_FRONTEND_URL` — already used elsewhere in this repo; defaults to `https://www.xrealty.ae`.

## Notes / scope

- The frontend `/api/revalidate` already allowlists the `redirects`, `articles`, and `article:*` tags, so no frontend change is needed.
- Article content lives in Strapi, not this service — so the article-detail cache is also bust here (via the redirect's target slug) because that's where a hub-move redirect is created. A Strapi save-webhook could additionally revalidate on pure content edits, but that's out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)