### PR TITLE
chore(schema): stop injecting RealEstateListing into schema_org

### DIFF
--- a/utils/updatePropertiesSchema/updatePropertiesSchema.js
+++ b/utils/updatePropertiesSchema/updatePropertiesSchema.js
@@ -3,17 +3,14 @@ const mongoose = require("mongoose");
 const Property = require("../../models/properties");
 
 /**
- * Clean a price string into a plain numeric value.
- * Handles formats like "AED 1,234,567", " 1,234,567", "1234567", etc.
+ * Backfills the FAQ schema (faqs_schema) for properties that have FAQs.
+ *
+ * NOTE: this script no longer generates the RealEstateListing markup
+ * (schema_org). That schema is now generated on the frontend (xr_client) from
+ * each property's live fields — the single source of truth — so generating it
+ * here would only write a duplicate/minimal copy (drift-prone priceValidUntil)
+ * that the site no longer reads. Only the FAQ schema is touched.
  */
-function cleanPrice(raw) {
-  if (!raw) return "0";
-  const cleaned = raw
-    .replace(/AED/gi, "")
-    .replace(/,/g, "")
-    .trim();
-  return cleaned || "0";
-}
 
 const updatePropertiesSchema = async () => {
   const DB_URL =
@@ -38,63 +35,32 @@ const updatePropertiesSchema = async () => {
 
     for (const property of properties) {
       try {
-        // Generate FAQs schema if property has FAQs
-        if (property.faqs && property.faqs.length > 0) {
-          const faqsSchema = {
-            "@context": "https://schema.org",
-            "@type": "FAQPage",
-            mainEntity: property.faqs.map((faq) => ({
-              "@type": "Question",
-              name: faq.question,
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: faq.answer,
-              },
-            })),
-          };
-          property.faqs_schema.properties = faqsSchema;
+        // RealEstateListing (schema_org) is intentionally NOT generated here —
+        // it's produced on the frontend (xr_client) from the property's live
+        // fields. Only the FAQ schema is refreshed; properties without FAQs are
+        // left untouched.
+        if (!property.faqs || property.faqs.length === 0) {
+          skipped++;
+          continue;
         }
 
-        // Set the schema_org type
-        property.schema_org.type = "RealEstateListing";
-
-        const propertyUrl = `https://www.xrealty.ae/property/${property.property_name_slug}/`;
-
-        // Generate main schema using RealEstateListing
-        const rawName = property.seo?.meta_title || property.property_name || "";
-        const name = rawName.includes("| Xperience Realty")
-          ? rawName
-          : `${rawName} | Xperience Realty`;
-
-        const mainSchema = {
+        property.faqs_schema.properties = {
           "@context": "https://schema.org",
-          "@type": "RealEstateListing",
-          name,
-          description:
-            property.seo?.meta_description || property.description,
-          url: propertyUrl,
-          image:
-            property.open_graph?.image || property.images?.[0]?.url || "",
-          offers: {
-            "@type": "Offer",
-            priceCurrency: "AED",
-            price: cleanPrice(property.price),
-            url: propertyUrl,
-            priceValidUntil: new Date(
-              new Date().setFullYear(new Date().getFullYear() + 1)
-            )
-              .toISOString()
-              .split("T")[0],
-            availability: "https://schema.org/LimitedAvailability",
-          },
+          "@type": "FAQPage",
+          mainEntity: property.faqs.map((faq) => ({
+            "@type": "Question",
+            name: faq.question,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: faq.answer,
+            },
+          })),
         };
-
-        property.schema_org.properties = mainSchema;
 
         await property.save();
         updated++;
         console.log(
-          `[${updated}/${properties.length}] Updated: ${property.property_name}`
+          `[${updated}/${properties.length}] FAQ schema updated: ${property.property_name}`
         );
       } catch (err) {
         skipped++;


### PR DESCRIPTION
Follow-up to the frontend SEO work (xr_client #21): the property **RealEstateListing** schema is now generated on the frontend from each property's live fields — the single source of truth. This backend script should no longer inject it.

## Change
`utils/updatePropertiesSchema/updatePropertiesSchema.js`:
- **Removed** the `schema_org` (RealEstateListing) generation — the frontend owns it now. (It was a minimal copy with a drift-prone `priceValidUntil` computed at run time; the frontend version is richer — nested `Accommodation` with address/geo/bedrooms — and always in sync.)
- **Removed** the now-unused `cleanPrice` helper.
- **Kept** the FAQ schema backfill (`faqs_schema`) — the frontend still renders it.

## Notes
- This script is **manual** (run with `node`, not a save hook), so nothing changes until it's next run; this just ensures it won't re-inject listing schema when it is.
- Existing `schema_org` values are left in place but are now **unused** by the site (the frontend ignores them). They can be cleared in a separate one-off if you want the DB scrubbed — say the word and I'll add that.
- No other injector exists (controllers/routes don't touch `schema_org`; model hooks are commented out).