### PR TITLE
fix(sitemap): bust the /sitemap.xml path (not just the tag) on regen

### DIFF
--- a/utils/generateSitemap/generateSitemap.js
+++ b/utils/generateSitemap/generateSitemap.js
@@ -33,10 +33,19 @@ const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET || "";
 
 function revalidateFrontendSitemap() {
   if (!REVALIDATE_SECRET) return; // not configured → rely on the frontend cache TTL
-  fetch(`${MAIN_FRONTEND_URL}/api/revalidate`, {
+  // POST to the trailing-slash URL directly (site is trailingSlash:true, so the
+  // bare path 308-redirects) and bust BOTH the cache tag AND the route path:
+  //   - tags:["sitemap"]      → the data cache of the admin/sitemap fetch
+  //   - paths:["/sitemap.xml"]→ the route's own response/edge cache (the route
+  //                             sets s-maxage, which the tag alone may not purge)
+  fetch(`${MAIN_FRONTEND_URL}/api/revalidate/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ secret: REVALIDATE_SECRET, tags: ["sitemap"] }),
+    body: JSON.stringify({
+      secret: REVALIDATE_SECRET,
+      tags: ["sitemap"],
+      paths: ["/sitemap.xml"],
+    }),
     signal: AbortSignal.timeout(5000),
   }).catch((err) => {
     console.error("[Sitemap] frontend revalidate failed:", err.message);


### PR DESCRIPTION
Follow-up to #149. After investigating "the live sitemap isn't updating," the frontend revalidation endpoint turned out to be **fine** — the gap is in *what* the backend asks it to bust.

## Findings (verified live)
- `POST https://www.xrealty.ae/api/revalidate/` with a bad secret → `401 {"error":"Invalid revalidation secret"}` → the handler is wired and running.
- The no-slash POST 308-redirects to `/api/revalidate/`; Node's `fetch` (the backend's runtime) follows it **with the body preserved**, so the call reaches the handler either way.
- `"sitemap"` is on the frontend's tag allowlist and `/sitemap.xml` passes its path validator.

So the endpoint works. The likely reason the live sitemap stayed stale: the frontend **`/sitemap.xml` route sets an explicit `Cache-Control: s-maxage=3600`** on its response. `revalidateTag("sitemap")` busts the *data cache* (the `admin/sitemap` fetch) but may not purge that route's edge-cached response — so the CDN keeps serving the old XML for up to an hour.

## Fix
`revalidateFrontendSitemap()` now:
1. Sends **`paths:["/sitemap.xml"]`** in addition to `tags:["sitemap"]` — `revalidatePath` purges the route's response/edge cache on Vercel (the reliable lever for a route with explicit `s-maxage`).
2. POSTs to **`/api/revalidate/`** (trailing slash) directly, skipping the 308 hop.

`node --check` passes; confirmed `/sitemap.xml` passes the frontend's `isValidPath`.

## Still verify on the backend env (not code)
For the ping to fire at all, **`REVALIDATE_SECRET` must be set on the backend and match the frontend's** (same secret PR #145 uses for redirects). If it's unset, the ping no-ops by design. After this deploys, a **Regenerate** click should flip the live sitemap within seconds — if it still doesn't, it's the secret/env.