### PR TITLE
fix(sitemap): make health check report-only by default

### DIFF
--- a/routes/generateSitemap.js
+++ b/routes/generateSitemap.js
@@ -149,7 +149,10 @@ router
   .route("/generateSitemap/health-check")
   .post(bearerAuth(ADMIN_SECRET), async (req, res) => {
     try {
-      const result = await runHealthCheck();
+      // Report-only by default; pass ?remove=true (or { remove: true }) to prune.
+      const result = await runHealthCheck(null, {
+        autoRemove: req.query.remove === "true" || req.body?.remove === true,
+      });
       return res.status(200).json(result);
     } catch (err) {
       return res.status(500).json({
@@ -166,7 +169,10 @@ router
   .route("/generateSitemap/health-check")
   .get(isLoggedIn, isAdmin, async (req, res) => {
     try {
-      const result = await runHealthCheck();
+      // Report-only by default; pass ?remove=true (or { remove: true }) to prune.
+      const result = await runHealthCheck(null, {
+        autoRemove: req.query.remove === "true" || req.body?.remove === true,
+      });
       return res.status(200).json(result);
     } catch (err) {
       return res.status(500).json({
@@ -209,10 +215,14 @@ router
     };
 
     try {
-      const result = await runHealthCheck((progress) => {
-        if (clientDisconnected) return;
-        sendEvent("progress", progress);
-      });
+      const result = await runHealthCheck(
+        (progress) => {
+          if (clientDisconnected) return;
+          sendEvent("progress", progress);
+        },
+        // Report-only by default; pass ?remove=true to prune.
+        { autoRemove: req.query.remove === "true" }
+      );
 
       sendEvent("done", result);
     } catch (err) {

--- a/utils/generateSitemap/sitemapHealthCheck.js
+++ b/utils/generateSitemap/sitemapHealthCheck.js
@@ -144,23 +144,53 @@ function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/** Human-readable reason for a bad URL result. */
+function describeBadResult(r) {
+  return r.statusCode === 0
+    ? `Request failed: ${r.error || "timeout"}`
+    : r.statusCode === 301 || r.statusCode === 308
+    ? `Permanent redirect → ${r.redirectTarget || "unknown"}`
+    : r.statusCode === 302 || r.statusCode === 307
+    ? `Temporary redirect → ${r.redirectTarget || "unknown"}`
+    : r.statusCode === 404
+    ? "Page not found"
+    : r.statusCode === 410
+    ? "Page gone (410)"
+    : `Server error (${r.statusCode})`;
+}
+
 /**
  * Main health check function.
  * 1. Reads all URLs from the sitemap
- * 2. Checks each URL for bad status codes (301, 404, etc.)
- * 3. Auto-removes bad URLs from the sitemap
+ * 2. Checks each URL for bad status codes (3xx / 404 / 410 / 5xx / timeout)
+ * 3. REPORTS the bad ones (default) — or removes them if explicitly opted in
  * 4. Logs everything to MongoDB
+ *
+ * REPORT-ONLY by default. Since PR #148 the generator emits only canonical 200
+ * URLs, so a redirect found here is almost always a real page caught mid-move
+ * (e.g. an article whose sub-category just changed, whose old nested URL now
+ * 308s). Auto-deleting those would drop live pages from the sitemap until the
+ * next full regen — net harm. Regeneration is the source of truth; this is a
+ * monitor. Editor/content changes already trigger a regen (Strapi webhook), so
+ * genuine drift self-heals there, not here.
  *
  * @param {function} onProgress - Optional callback for progress events.
  *   Called with { phase, checked, total, ... } objects.
+ * @param {{autoRemove?: boolean}} [options] - Pass { autoRemove: true } to opt
+ *   INTO the old destructive behaviour (prune flagged URLs from disk + MongoDB).
+ *   Use only after reviewing the report.
  *
  * Returns a summary object.
  */
-async function runHealthCheck(onProgress) {
+async function runHealthCheck(onProgress, { autoRemove = false } = {}) {
   const startTime = Date.now();
   const auditRunId = crypto.randomUUID();
 
-  console.log(`[SitemapAudit] Starting health check (run: ${auditRunId})...`);
+  console.log(
+    `[SitemapAudit] Starting health check (run: ${auditRunId}, mode: ${
+      autoRemove ? "auto-remove" : "report-only"
+    })...`
+  );
 
   // 1. Extract URLs
   const urls = extractUrlsFromSitemap();
@@ -189,37 +219,34 @@ async function runHealthCheck(onProgress) {
 
   if (onProgress) {
     onProgress({
-      phase: "removing",
+      phase: autoRemove ? "removing" : "reporting",
       total: urls.length,
       checked: urls.length,
       badUrls: badResults.length,
     });
   }
 
+  let removed = 0;
   if (badResults.length > 0) {
-    // 4. Remove bad URLs from sitemap
-    const urlsToRemove = badResults.map((r) => r.url);
-    const removedCount = await removeUrlsFromSitemap(urlsToRemove);
-    console.log(`[SitemapAudit] Removed ${removedCount} URLs from sitemap`);
+    // 4. Remove ONLY when explicitly opted in; otherwise leave the sitemap
+    //    untouched (report-only). The generator is the source of truth.
+    if (autoRemove) {
+      removed = await removeUrlsFromSitemap(badResults.map((r) => r.url));
+      console.log(`[SitemapAudit] Removed ${removed} URLs from sitemap`);
+    } else {
+      console.log(
+        `[SitemapAudit] Report-only — sitemap left unchanged (${badResults.length} flagged)`
+      );
+    }
 
-    // 5. Log to MongoDB
+    // 5. Log to MongoDB — action reflects whether we removed or just flagged.
+    const action = autoRemove ? "removed" : "flagged";
     const logEntries = badResults.map((r) => ({
       url: r.url,
       statusCode: r.statusCode,
       redirectTarget: r.redirectTarget,
-      action: "removed",
-      reason:
-        r.statusCode === 0
-          ? `Request failed: ${r.error || "timeout"}`
-          : r.statusCode === 301 || r.statusCode === 308
-          ? `Permanent redirect → ${r.redirectTarget || "unknown"}`
-          : r.statusCode === 302 || r.statusCode === 307
-          ? `Temporary redirect → ${r.redirectTarget || "unknown"}`
-          : r.statusCode === 404
-          ? "Page not found"
-          : r.statusCode === 410
-          ? "Page gone (410)"
-          : `Server error (${r.statusCode})`,
+      action,
+      reason: describeBadResult(r),
       auditRunId,
     }));
 
@@ -230,20 +257,23 @@ async function runHealthCheck(onProgress) {
   const elapsed = Date.now() - startTime;
   const summary = {
     success: true,
+    mode: autoRemove ? "auto-remove" : "report-only",
     auditRunId,
     totalChecked: urls.length,
     badUrls: badResults.length,
-    removed: badResults.length,
+    flagged: badResults.length,
+    removed,
     elapsed,
     details: badResults.map((r) => ({
       url: r.url,
       statusCode: r.statusCode,
       redirectTarget: r.redirectTarget,
+      reason: describeBadResult(r),
     })),
   };
 
   console.log(
-    `[SitemapAudit] Health check complete — ${badResults.length} removed in ${elapsed}ms`
+    `[SitemapAudit] Health check complete — ${badResults.length} flagged, ${removed} removed in ${elapsed}ms`
   );
 
   if (onProgress) {


### PR DESCRIPTION
## Why
The sitemap health check pings every URL and **auto-deletes** any that return a redirect / 404 / 5xx — from both disk and MongoDB.

That was the right call when the generator emitted redirecting flat blog URLs (the health check was the cleanup crew). But since **#148** the generator emits only canonical **200** URLs and excludes redirect sources — so the proofreader has nothing to scrub. Worse, it treats **308 as "bad" and removes it**, and our entire canonical scheme *is* 308s. A real page caught mid-move (e.g. an article whose `sub_category` just changed, so its old nested URL now 308s for ~30s before the next regen) would get **silently deleted from the live sitemap** until a full regenerate re-adds it. The auditor can now do net harm.

With content edits already triggering a regen (Strapi webhook → `/api/sitemap/regenerate`), genuine drift self-heals at the source. The health check only needs to **report**.

## What changed
- `runHealthCheck(onProgress, { autoRemove = false })` — **report-only by default**: it still pings every URL and reports/loggs the bad ones, but **does not modify the sitemap**.
- Removal is now **opt-in**:
  - `GET /generateSitemap/health-check?remove=true` (and the `…-stream` SSE variant)
  - `POST /generateSitemap/health-check` with `{ "remove": true }`
- Flagged URLs are logged with `action: "flagged"` (the `SitemapAuditLog` model's enum **already** included `"flagged"`) instead of `"removed"`.
- Summary gains `mode` + `flagged` and each `details[]` now carries a human-readable `reason`. `removed` / `badUrls` / `details` are unchanged — **backward-compatible** with the admin UI.

## Safety
- Default path no longer writes to disk or MongoDB.
- Opt-in `autoRemove: true` preserves the exact old behaviour for the rare case an admin deliberately wants to prune after reviewing the report.
- `node --check` passes on both files.